### PR TITLE
用紙サイズ変更に伴うレイアウトの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npx grunt && npx savepdf dist/",
-    "preview": "npx grunt && npx savepdf --preview dist/"
+    "build": "grunt && savepdf dist/ -s 182mm,257mm",
+    "preview": "grunt && savepdf dist/ -s 182mm,257mm --preview"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "grunt && savepdf dist/ -s 182mm,257mm",
-    "preview": "grunt && savepdf dist/ -s 182mm,257mm --preview"
+    "build": "grunt && savepdf dist/ -s 148mm,210mm",
+    "preview": "grunt && savepdf dist/ -s 148mm,210mm --preview"
   },
   "repository": {
     "type": "git",

--- a/templates/assets/css/main.css
+++ b/templates/assets/css/main.css
@@ -147,7 +147,7 @@ h1::before {
   /* sizeは印刷するページの大きさを指定します。
     * 下のような幅と高さの指定以外にも、A4やJIS-B5などが指定できます。
     */
-  size: 182mm 257mm;
+  size: 148mm 210mm;
   /* @bottom-leftはページの左下の疑似要素について指定する特別なルールです。
     * これ以外にも、@top-centerなどが指定できます。
     * 参考: https://www.w3.org/TR/css3-page/#margin-boxes

--- a/templates/assets/css/main.css
+++ b/templates/assets/css/main.css
@@ -9,11 +9,11 @@ html, html * {
   */
 
 body {
-  margin: 50px auto;
-  padding: 0 40px;
+  margin: 30px auto;
+  padding: 0 20px;
   max-width: 660px;
   font-family: 'ipag';
-  font-size: 16px;
+  font-size: 11px;
   letter-spacing: 0.02em;
   line-height: 1.7;
   /* word-breakは英単語の改行ルールを指定します */
@@ -27,7 +27,7 @@ body {
 p {
   margin: 24px 0;
   /* text-indentは行頭の空白のサイズを設定します */
-  text-indent: 1em;
+  text-indent: 0.5em;
 }
 
 h1, h2, h3, h4, h5 {
@@ -116,7 +116,7 @@ h1::before {
 
 @media print {
   body {
-    font-size: 14px;
+    font-size: 11px;
     /* widows, orhpansは改ページで文章が分断された時に
       * 先頭（末尾）の行を最低何行確保するかを指定します。
       */
@@ -159,11 +159,11 @@ h1::before {
       * 何も表示させない場合は空文字（''）を指定してください。
       */
     content: counter(page);
-    font-size: 12px;
+    font-size: 9px;
   }
   @bottom-right {
     content: 'テストテストテストテスト';
-    font-size: 12px;
+    font-size: 9px;
   }
 }
 
@@ -172,11 +172,11 @@ h1::before {
   */
 
 @page :right {
-  margin: 17mm 15mm 23mm 20mm;
+  margin: 10mm 10mm 15mm 12mm;
 }
 
 @page :left {
-  margin: 17mm 20mm 23mm 15mm;
+  margin: 10mm 12mm 15mm 10mm;
 }
 
 pre {


### PR DESCRIPTION
Fixes #7 

- `savepdf` でsizeを指定することでWarning出ないように
- `npx` 不要なので削除

