### PR TITLE
コードブロックのスクロールバー削除

### DIFF
--- a/imasbook02/templates/assets/css/main.css
+++ b/imasbook02/templates/assets/css/main.css
@@ -165,7 +165,7 @@ article {
 
 article pre {
   padding: 16px;
-  overflow: auto;
+  overflow: hidden;
   font-size: 85%;
   line-height: 1.45;
   background-color: #f6f8fa;


### PR DESCRIPTION
コードブロックの右端ぎりぎりまでの長さのコードがある場合に、スクロールバーが表示されてしまうので対応。