### PR TITLE
footnoteがあると画像がセンタリングされない問題の対処

### DIFF
--- a/imasbook02/Gruntfile.js
+++ b/imasbook02/Gruntfile.js
@@ -18,6 +18,9 @@ module.exports = function (grunt) {
                     template: 'templates/section.jst',
                     markdownOptions: {
                         gfm: true
+                    },
+                    postCompile: function(src, context) {
+                      return src.replace(/<p><img src=/g, "<p class=\"imageHolder\"><img src=");
                     }
                 }
             }

--- a/imasbook02/Gruntfile.js
+++ b/imasbook02/Gruntfile.js
@@ -20,7 +20,10 @@ module.exports = function (grunt) {
                         gfm: true
                     },
                     postCompile: function(src, context) {
-                      return src.replace(/<p><img src=/g, "<p class=\"imageHolder\"><img src=");
+                      return src
+                        .replace(/<p><img src=/g, "<p class=\"imageHolder\"><img src=")
+                        .replace(/<table>/g, "<div class=\"tableHolder\"><table>")
+                        .replace(/<\/table>/g, "</table></div>");
                     }
                 }
             }

--- a/imasbook02/templates/assets/css/main.css
+++ b/imasbook02/templates/assets/css/main.css
@@ -47,7 +47,7 @@ article p.imageHolder {
 
 article img {
   display: inline;
-  margin: 10px auto;
+  margin: 0px auto;
   max-width: 80%;
 }
 
@@ -175,7 +175,12 @@ article pre {
   border-radius: 3px;
 }
 
+article div.tableHolder {
+  text-align: center;
+}
+
 article table{
+  display: inline;
   margin:0 auto;
   border-spacing: 2px 0px;
 }

--- a/imasbook02/templates/assets/css/main.css
+++ b/imasbook02/templates/assets/css/main.css
@@ -41,8 +41,12 @@ article {
   border-radius: 0.2em;
 }
 
+article p.imageHolder {
+  text-align: center;
+}
+
 article img {
-  display: block;
+  display: inline;
   margin: 10px auto;
   max-width: 80%;
   box-shadow: 0px 4px 8px 2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
footnoteがあるページでは、画像がセンタリングされない問題の対処

### 補足
「float:footnote;」の要素がページ内にあると、
以下の指定では、上手くimageがセンタリングされないようです。
```
<img style="display:block;margin:10px auto;">
```

強引な対応ですが、
以下のように書くとセンタリングされるので、img上位のp要素にtext-alignを指定してます。
```
<center>
<img style="display:inline;">
</center>
```