### PR TITLE
URLリンクの下線削除

### DIFF
--- a/imasbook02/templates/assets/css/main.css
+++ b/imasbook02/templates/assets/css/main.css
@@ -29,6 +29,10 @@ article p {
   text-indent: 0.5em;
 }
 
+article a {
+  text-decoration: none
+}
+
 article {
   page-break-before: always;
   page-break-after: always;


### PR DESCRIPTION
URLリンクの下線、美しくないので外したいです

理由:
- 強調箇所よりも目立ってしまう
- y, g, qとかがあると線が切れ切れになる